### PR TITLE
Fixing Github Deployment Triggers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,13 +12,17 @@ env:
   GOOGLE_CLOUD_PROJECT: launch-the-nukes
   REGION: us-central1
 
+concurrency:
+  group: deploy-${{ github.repository }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     name: Deploy to GCP
     runs-on: ubuntu-latest
     
     # Only run on main/master branch pushes or merged PRs
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || (github.event.pull_request.merged == true && (github.event.pull_request.base.ref == 'main' || github.event.pull_request.base.ref == 'master'))
+    if: github.repository == 'JustinCappos/launch-the-nukes' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || (github.event.pull_request.merged == true && (github.event.pull_request.base.ref == 'main' || github.event.pull_request.base.ref == 'master')))
     
     steps:
     - name: Checkout code

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,7 @@ env:
   GOOGLE_CLOUD_PROJECT: launch-the-nukes
   REGION: us-central1
 
+# To make sure that when one action runs, the other does not get executed parallely
 concurrency:
   group: deploy-${{ github.repository }}
   cancel-in-progress: false


### PR DESCRIPTION
- Added a check that only the base repository will have its action triggered to run Deploy to GCP action.
- Added condition to control concurrent Github actions being triggered, queuing the actions.

#31 